### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/mutation/tarballs.go
+++ b/mutation/tarballs.go
@@ -30,6 +30,9 @@ func sanitizePath(path string) (string, error) {
 		return "", fmt.Errorf("path traversal attempt: %s", path)
 	}
 	cleanPath := filepath.Clean(path)
+	if strings.Contains(cleanPath, "..") {
+		return "", fmt.Errorf("path traversal attempt: %s", path)
+	}
 	return cleanPath, nil
 }
 

--- a/mutation/tarballs.go
+++ b/mutation/tarballs.go
@@ -83,7 +83,7 @@ func ExtractTarball(src, dst string, force, stripRoot bool) error {
 				isTopLevel = true
 			}
 		}
-		fmt.Printf("extracting: %s\n", target)
+		log.Debug().Msgf("extracting: %s", target)
 		switch header.Typeflag {
 		case tar.TypeDir:
 			if !isTopLevel {


### PR DESCRIPTION
Potential fix for [https://github.com/brucehq/bruce/security/code-scanning/1](https://github.com/brucehq/bruce/security/code-scanning/1)

To fix the problem, we need to ensure that the path does not contain any `..` elements after cleaning it. This can be done by adding an additional check in the `sanitizePath` function to ensure that the cleaned path does not contain any `..` elements. This will prevent directory traversal attacks by ensuring that the extracted files do not escape the intended destination directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
